### PR TITLE
[Security] Fix CodeQL alert #27: XML external entity expansion

### DIFF
--- a/vulnerable_xxe.py
+++ b/vulnerable_xxe.py
@@ -1,6 +1,7 @@
 import xml.etree.ElementTree as ET
 from flask import Flask, request
 from lxml import etree
+import defusedxml.lxml as defused_lxml
 import xml.sax
 
 app = Flask(__name__)
@@ -17,8 +18,7 @@ def parse_xml():
 def process_xml():
     xml_content = request.data.decode()
     
-    parser = etree.XMLParser()
-    doc = etree.fromstring(xml_content.encode(), parser)
+    doc = defused_lxml.fromstring(xml_content.encode())
     
     return etree.tostring(doc).decode()
 


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #27: XML external entity expansion

| Field | Value |
|-------|-------|
| **Severity** | critical |
| **File** | `vulnerable_xxe.py` |
| **CWE** | [CWE-611](https://cwe.mitre.org/data/definitions/611.html) |
| **Alert** | [CodeQL Alert #27](https://github.com/colin-d-fried/demo-python/security/code-scanning/27) |

### Fix Applied
See the diff for the specific secure coding change applied.

Fixes #29
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/colin-d-fried/demo-python/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes XML parsing for the `/process_xml` endpoint to use `defusedxml`, which may reject previously accepted XML (e.g., DTD/entity usage) but reduces XXE risk in a request-handling path.
> 
> **Overview**
> Mitigates the CodeQL XXE finding by switching the `/process_xml` handler from `lxml.etree.XMLParser` + `etree.fromstring` to `defusedxml.lxml.fromstring`, and adds the corresponding import.
> 
> This makes XML parsing safer by default and may change behavior for inputs that rely on external entities/DTDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e99d156d62d1ff2e4d1010a114f1992b0880ace8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->