### PR TITLE
[Security] Fix CodeQL alert #34: Deserialization of user-controlled data

### DIFF
--- a/vulnerable_deserialization.py
+++ b/vulnerable_deserialization.py
@@ -1,4 +1,4 @@
-import pickle
+import json
 import yaml
 import marshal
 from flask import Flask, request
@@ -9,7 +9,7 @@ app = Flask(__name__)
 def load_data():
     data = request.data
     
-    obj = pickle.loads(data)
+    obj = json.loads(data)
     
     return str(obj)
 


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #34: Deserialization of user-controlled data

| Field | Value |
|-------|-------|
| **Severity** | critical |
| **File** | `vulnerable_deserialization.py` |
| **CWE** | [CWE-502](https://cwe.mitre.org/data/definitions/502.html) |
| **Alert** | [CodeQL Alert #34](https://github.com/colin-d-fried/demo-python/security/code-scanning/34) |

### Fix Applied
See the diff for the specific secure coding change applied.

Fixes #36

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes request deserialization behavior and removes the `pickle` import while other code paths still call `pickle.loads`, which can cause runtime failures and leaves other unsafe deserializations unchanged.
> 
> **Overview**
> Updates `vulnerable_deserialization.py` to stop using `pickle.loads` on raw POST body data in the `/load` route, switching to `json.loads` and replacing the `pickle` import with `json`.
> 
> Other routes and helpers still call `pickle.loads` (now without importing `pickle`), so the PR likely introduces `NameError` at runtime and does not address remaining user-controlled deserialization sites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ecbdfc5cc53313e6a1a3c5b268e525f5902e1a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->