### PR TITLE
[Security] Fix CodeQL alert #35: Deserialization of user-controlled data

### DIFF
--- a/vulnerable_deserialization.py
+++ b/vulnerable_deserialization.py
@@ -17,7 +17,8 @@ def load_data():
 def restore_session():
     session_data = request.form.get('session')
     
-    session = pickle.loads(session_data.encode())
+    import json as _json
+    session = _json.loads(session_data)
     
     return f"Session restored: {session}"
 


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #35: Deserialization of user-controlled data

| Field | Value |
|-------|-------|
| **Severity** | critical |
| **File** | `vulnerable_deserialization.py` |
| **CWE** | [CWE-502](https://cwe.mitre.org/data/definitions/502.html) |
| **Alert** | [CodeQL Alert #35](https://github.com/colin-d-fried/demo-python/security/code-scanning/35) |

### Fix Applied
See the diff for the specific secure coding change applied.

Fixes #37
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/colin-d-fried/demo-python/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reduces RCE risk by replacing `pickle.loads` on user-provided session data with JSON parsing, but may change accepted session formats and error behavior for the `/session` endpoint.
> 
> **Overview**
> Mitigates CodeQL CWE-502 by changing the `/session` restore path in `vulnerable_deserialization.py` to parse user-provided `session` data with `json.loads` instead of `pickle.loads`.
> 
> This removes insecure deserialization from that endpoint, trading it for a JSON-only session payload expectation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da5d2339de1774b2619d25d5e57ab44553c6af45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->