### PR TITLE
[Security] Fix CodeQL alert #28: Uncontrolled data used in path expression

### DIFF
--- a/vulnerable_path_traversal.py
+++ b/vulnerable_path_traversal.py
@@ -7,7 +7,10 @@ app = Flask(__name__)
 def download_file():
     filename = request.args.get('file')
     
-    file_path = os.path.join('/var/www/uploads/', filename)
+    base_dir = '/var/www/uploads/'
+    file_path = os.path.realpath(os.path.join(base_dir, filename))
+    if not file_path.startswith(os.path.realpath(base_dir)):
+        return 'Access denied', 403
     return send_file(file_path)
 
 @app.route('/read')


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #28: Uncontrolled data used in path expression

| Field | Value |
|-------|-------|
| **Severity** | high |
| **File** | `vulnerable_path_traversal.py` |
| **CWE** | [CWE-022](https://cwe.mitre.org/data/definitions/22.html) |
| **Alert** | [CodeQL Alert #28](https://github.com/colin-d-fried/demo-python/security/code-scanning/28) |

### Fix Applied
See the diff for the specific secure coding change applied.

Fixes #30
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/colin-d-fried/demo-python/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk, localized security hardening in `download_file` that changes path resolution and may reject previously-accepted (but unsafe) inputs.
> 
> **Overview**
> Hardens the `/download` endpoint in `vulnerable_path_traversal.py` against path traversal by resolving the requested filename with `os.path.realpath` and enforcing that the resulting path stays under the `/var/www/uploads/` base directory.
> 
> Requests that resolve outside the allowed directory now return `403 Access denied` instead of attempting to `send_file` the path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cde6d9323a87dcd77416fa10fec24885fd6ba337. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->