### PR TITLE
[Security] Fix CodeQL alert #29: Uncontrolled data used in path expression

### DIFF
--- a/vulnerable_path_traversal.py
+++ b/vulnerable_path_traversal.py
@@ -14,7 +14,11 @@ def download_file():
 def read_file():
     file_name = request.args.get('filename', 'default.txt')
     
-    with open(file_name, 'r') as f:
+    base_dir = os.path.realpath('/var/www/files/')
+    safe_path = os.path.realpath(os.path.join(base_dir, file_name))
+    if not safe_path.startswith(base_dir):
+        return 'Access denied', 403
+    with open(safe_path, 'r') as f:
         content = f.read()
     
     return content


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #29: Uncontrolled data used in path expression

| Field | Value |
|-------|-------|
| **Severity** | high |
| **File** | `vulnerable_path_traversal.py` |
| **CWE** | [CWE-022](https://cwe.mitre.org/data/definitions/22.html) |
| **Alert** | [CodeQL Alert #29](https://github.com/colin-d-fried/demo-python/security/code-scanning/29) |

### Fix Applied
See the diff for the specific secure coding change applied.

Fixes #31
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/colin-d-fried/demo-python/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds path canonicalization and base-directory enforcement for user-supplied filenames; low code churn but touches file-system access where mistakes could still allow bypasses or block legitimate files.
> 
> **Overview**
> Hardens the `/read` endpoint in `vulnerable_path_traversal.py` by resolving the requested `filename` against a fixed base directory and denying requests whose real path escapes that directory.
> 
> This replaces direct `open(file_name)` with `realpath`-based validation and reads from the validated `safe_path`, returning `403` on traversal attempts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 935aa5da7b1487881fe919a6589285fafd9143b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->