### PR TITLE
[Security] Fix CodeQL alert #30: Uncontrolled data used in path expression

### DIFF
--- a/vulnerable_path_traversal.py
+++ b/vulnerable_path_traversal.py
@@ -22,7 +22,10 @@ def read_file():
 @app.route('/view')
 def view_document():
     doc = request.args.get('doc')
-    path = f"/documents/{doc}"
+    base_dir = os.path.realpath("/documents/")
+    path = os.path.realpath(os.path.join(base_dir, doc))
+    if not path.startswith(base_dir):
+        return 'Access denied', 403
     
     with open(path) as file:
         return file.read()


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #30: Uncontrolled data used in path expression

| Field | Value |
|-------|-------|
| **Severity** | high |
| **File** | `vulnerable_path_traversal.py` |
| **CWE** | [CWE-022](https://cwe.mitre.org/data/definitions/22.html) |
| **Alert** | [CodeQL Alert #30](https://github.com/colin-d-fried/demo-python/security/code-scanning/30) |

### Fix Applied
See the diff for the specific secure coding change applied.

Fixes #32

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces path canonicalization and a base-directory check for user-supplied document paths, which can affect file access behavior and potentially block previously reachable paths. Low code churn, but touches security-sensitive file I/O and relies on correct path validation.
> 
> **Overview**
> Fixes a path traversal risk in `view_document` by resolving the requested `doc` path against a canonical `/documents/` base directory and denying requests that escape that directory.
> 
> Replaces string path construction with `os.path.realpath(os.path.join(...))` and returns `403` on validation failure before reading the file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b3a9cd463150a7190318d32cfa7c1f2001bad66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/colin-d-fried/demo-python/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
