### PR TITLE
[Security] Fix CodeQL alert #33: XML internal entity expansion

### DIFF
--- a/vulnerable_xxe.py
+++ b/vulnerable_xxe.py
@@ -47,7 +47,8 @@ def upload_xml():
     xml_file = request.files['file']
     content = xml_file.read()
     
-    root = ET.fromstring(content)
+    import defusedxml.ElementTree as SafeET
+    root = SafeET.fromstring(content)
     
     return f"Uploaded: {root.tag}"
 


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #33: XML internal entity expansion

| Field | Value |
|-------|-------|
| **Severity** | high |
| **File** | `vulnerable_xxe.py` |
| **CWE** | [CWE-776](https://cwe.mitre.org/data/definitions/776.html) |
| **Alert** | [CodeQL Alert #33](https://github.com/colin-d-fried/demo-python/security/code-scanning/33) |

### Fix Applied
See the diff for the specific secure coding change applied.

Fixes #35
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/colin-d-fried/demo-python/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change that only swaps the XML parser used by the `/upload_xml` endpoint. Main risk is potential behavior differences or parse errors for previously accepted XML inputs.
> 
> **Overview**
> Updates the `/upload_xml` endpoint in `vulnerable_xxe.py` to parse uploaded XML with `defusedxml.ElementTree` (`SafeET.fromstring`) instead of the standard `xml.etree.ElementTree`, mitigating XML internal entity expansion (XXE/Billion Laughs) issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e452d9913f9bfd2046aada1108c1c78d44ec5e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->