### PR TITLE
[Security] Fix CodeQL alert #45: Reflected server-side cross-site scripting

### DIFF
--- a/vulnerable_xss.py
+++ b/vulnerable_xss.py
@@ -1,3 +1,4 @@
+from markupsafe import escape
 from flask import Flask, request, render_template_string, make_response
 
 app = Flask(__name__)
@@ -10,7 +11,7 @@ def hello():
 
 @app.route('/comment', methods=['POST'])
 def post_comment():
-    comment = request.form.get('comment', '')
+    comment = escape(request.form.get('comment', ''))
     
     html = f"""
     <html>


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #45: Reflected server-side cross-site scripting

| Field | Value |
|-------|-------|
| **Severity** | medium |
| **File** | `vulnerable_xss.py` |
| **CWE** | [CWE-079](https://cwe.mitre.org/data/definitions/79.html) |
| **Alert** | [CodeQL Alert #45](https://github.com/colin-d-fried/demo-python/security/code-scanning/45) |

### Fix Applied
See the diff for the specific secure coding change applied.

Fixes #47
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/colin-d-fried/demo-python/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, narrowly scopes behavior change to HTML-escaping the `/comment` form value before rendering to mitigate reflected XSS.
> 
> **Overview**
> Mitigates a reflected XSS vector in `vulnerable_xss.py` by **HTML-escaping user-supplied `comment` input** before embedding it in the `/comment` response.
> 
> Adds `markupsafe.escape` and applies it when reading `request.form['comment']`, so rendered comments are treated as text rather than raw HTML/JS.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b992a7c5ddaf6dba986a9fafe2619b7f337c247b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->